### PR TITLE
feat: do not sort union and intersection types

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -79,7 +79,6 @@ module.exports = {
 				"@typescript-eslint/prefer-nullish-coalescing": ["error"],
 				"@typescript-eslint/prefer-readonly": ["error"],
 				"@typescript-eslint/promise-function-async": ["error", { checkArrowFunctions: false }],
-				"@typescript-eslint/sort-type-union-intersection-members": ["error"],
 				"@typescript-eslint/switch-exhaustiveness-check": ["error"],
 				"@typescript-eslint/no-unused-vars": "off",
 			},


### PR DESCRIPTION
Why: After testing it out in a large codebase, we have seen that this rule warms the code readability instead of improving it. This is because we normally try to order type intersections conceptually. Examples:

```diff
-export type ButtonVariations = "primary" | "secondary" | "tertiary" | "inverted"; // conceptually ordered. Better.
+export type ButtonVariations = "inverted" | "primary" | "secondary" | "tertiary"; //alphabetically ordered. Worse.
```

```diff
-size?: "small" | "medium" | "large" | "xl"; // conceptually ordered. Better.
+size?: "large" | "medium" | "small" | "xl"; //alphabetically ordered. Worse.
```