### PR TITLE
feat: allow parentheses in folder naming convention

### DIFF
--- a/configs/codely-full.js
+++ b/configs/codely-full.js
@@ -25,8 +25,8 @@ export default [
 			"check-file/folder-naming-convention": [
 				"error",
 				{
-					// kebab-case and folders with square brackets are allowed
-					"**/*": "+([a-z-\\[\\]])",
+					// kebab-case and folders with square brackets and parentheses are allowed
+					"**/*": "+([a-z-\\[\\]\\(\\)])",
 				},
 			],
 			"simple-import-sort/imports": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-codely",
-	"version": "4.3.0",
+	"version": "4.2.0",
 	"description": "Codely's ESLint and Prettier Config",
 	"main": "index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-codely",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"description": "Codely's ESLint and Prettier Config",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
In order to allow the creation of [route groups as Next allows](https://nextjs.org/docs/app/building-your-application/routing/route-groups), it is necessary that the name of the files allow to have parenthesis.