### PR TITLE
fix: avoid using GitHub Personal Access Token while publishing a new release

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -17,8 +17,6 @@ jobs:
       - name: 🍄 Bump package version, create GitHub release, and update changelog
         uses: googleapis/release-please-action@v4
         id: release
-        with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Why: force open bump version PRs as GitHub bot

Why we were using GH PACs before: it is the recommendation by Release please to be able to run further GitHub Actions triggered by the PR opened by Release please. However, we are not interested in that behavior because we do not have CI test workflows in this repository, and even in that case, that tests would have already run in their corresponding PRs.

PS: Sorry for using `fix` SemVer type. It should be a `ci`, but we are testing out the automated release process and need to trigger it to create a PR 🙏